### PR TITLE
Fix broken link to jupyter notebooks

### DIFF
--- a/flask-new/templates/index.html
+++ b/flask-new/templates/index.html
@@ -104,7 +104,7 @@
                 {% endfor %}
             </li>
             <li style="list-style:none;">See a more detailed version available at <a href="http://takwatanabe.me/data_science/" style="border-bottom: dotted 1px rgba(88, 88, 88, 0.0)"><span style="color:blue;">takwatanabe.me/data_science</span></a></li>
-            <li><strong>My Jupyter notebook</strong> (<a href="http://nbviewer.jupyter.org/github/wtak23/jupyter-notes//">link</a>)</li>
+            <li><strong>My Jupyter notebook</strong> (<a href="http://nbviewer.jupyter.org/github/wtak23/jupyter-notes/">link</a>)</li>
         </ul>
 
         {# <h2>Personal (jumbled) Coding Notes</h2>


### PR DESCRIPTION
404 Not Found is displayed now.

And I'm sorry that a new line is added to the end of the file by GitHub online editor.